### PR TITLE
Fix an error when trying to get the line of a no context frame

### DIFF
--- a/crashtest/frame.py
+++ b/crashtest/frame.py
@@ -1,6 +1,6 @@
 import inspect
 
-from types import TracebackType
+from types import FrameType
 from typing import Dict
 
 
@@ -17,7 +17,7 @@ class Frame:
         self._file_content = None
 
     @property
-    def frame(self) -> TracebackType:
+    def frame(self) -> FrameType:
         return self._frame
 
     @property
@@ -34,6 +34,9 @@ class Frame:
 
     @property
     def line(self) -> str:
+        if not self._frame_info.code_context:
+            return ""
+
         return self._frame_info.code_context[0]
 
     @property

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -35,3 +35,9 @@ def test_frame():
     assert other_frame != frame
     assert hash(same_frame) == hash(frame)
     assert hash(other_frame) != hash(frame)
+
+
+def test_frame_with_no_context_should_return_empty_line():
+    frame = Frame(inspect.FrameInfo(None, "filename.py", 123, "function", None, 3))
+
+    assert "" == frame.line


### PR DESCRIPTION
When trying to get the line of the frame that did not have any context, it would raise an error. This PR fixes it.