### PR TITLE
Fix UnicodeDecodeError for non-English users

### DIFF
--- a/crashtest/frame.py
+++ b/crashtest/frame.py
@@ -47,7 +47,7 @@ class Frame:
             else:
                 if self._filename not in self.__class__._content_cache:
                     try:
-                        with open(self._filename) as f:
+                        with open(self._filename, encoding='utf-8') as f:
                             file_content = f.read()
                     except OSError:
                         file_content = ""


### PR DESCRIPTION
### Fixed

- Fixed a decoding error by forcing `'utf-8'` encoding when opening a file.  #5  
    - (Some non-English users uses `cp949` codec, which raises `UnicodeDecodeError`.)
